### PR TITLE
fix: intent check

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import { Linking, NativeModules, Platform } from "react-native";
 const { RNLinkingWithIntent } = NativeModules;
 
 const openURL = (url) => {
-  if (Platform.OS !== "android" || url.indexOf("intent://") !== 0) return Linking.openURL(url);
+  if (Platform.OS !== "android" || url.indexOf("intent:") !== 0) return Linking.openURL(url);
 
   if (RNLinkingWithIntent) {
     return RNLinkingWithIntent.openURL(url);
@@ -14,7 +14,7 @@ const openURL = (url) => {
 };
 
 const canOpenURL = (url) => {
-  if (Platform.OS !== "android" || url.indexOf("intent://") !== 0) return Linking.canOpenURL(url);
+  if (Platform.OS !== "android" || url.indexOf("intent:") !== 0) return Linking.canOpenURL(url);
 
   if (RNLinkingWithIntent) {
     return RNLinkingWithIntent.canOpenURL(url);


### PR DESCRIPTION
Fix intent check to follow internal Android check specs.
[source](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/java/android/content/Intent.java)

It solves the issue of not being able to run an intent command sometimes.
Some apps actually use a scheme like `intent:${SOME_VARIABLE}`, and internal check disallows the use of this library.